### PR TITLE
Fix H1 Tests

### DIFF
--- a/src/graderPublic/java/h13/json/JsonEnemy.java
+++ b/src/graderPublic/java/h13/json/JsonEnemy.java
@@ -4,14 +4,19 @@ import com.fasterxml.jackson.databind.JsonNode;
 import h13.model.gameplay.GameState;
 import h13.model.gameplay.sprites.Enemy;
 
+import static h13.util.StudentLinks.SpriteLinks.SpriteMethodLink.IS_DEAD_METHOD;
+import static org.mockito.Mockito.spy;
+
 public record JsonEnemy(int xIndex, int yIndex, int x, int y, int velocity, int health) implements JsonDataClass<Enemy> {
     public static GameState gameState;
 
     @Override
     public Enemy deserialize() {
-        final var enemy = new Enemy(xIndex, yIndex, velocity, health, gameState);
+        final var enemy = spy(new Enemy(xIndex, yIndex, velocity, health, gameState));
         enemy.setX(x);
         enemy.setY(y);
+
+        IS_DEAD_METHOD.doReturnAlways(enemy, health <= 0);
         return enemy;
     }
 

--- a/src/graderPublic/java/h13/model/gameplay/sprites/BattleShipTest.java
+++ b/src/graderPublic/java/h13/model/gameplay/sprites/BattleShipTest.java
@@ -20,9 +20,13 @@ import org.tudalgo.algoutils.tutor.general.assertions.Context;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
+import static h13.util.StudentLinks.BattleShipLinks.BattleShipMethodLink.IS_FRIEND_METHOD;
+import static h13.util.StudentLinks.BattleShipLinks.BattleShipMethodLink.SHOOT_METHOD;
 import static h13.util.StudentLinks.SpriteLinks.SpriteMethodLink.DIE_METHOD;
+import static h13.util.StudentLinks.SpriteLinks.SpriteMethodLink.IS_ALIVE_METHOD;
 import static org.mockito.Mockito.*;
 import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.*;
 
@@ -54,7 +58,7 @@ public class BattleShipTest {
             .add("Battleship 2", ship2)
             .build();
 
-        assertEquals(isFriend, ship1.isFriend(ship2), context, r -> "Ship was not correctly identified as Friend or Foe.");
+        assertEquals(isFriend, IS_FRIEND_METHOD.invoke(context, ship1, ship2), context, r -> "Ship was not correctly identified as Friend or Foe.");
     }
 
     @CartesianTest
@@ -65,7 +69,7 @@ public class BattleShipTest {
             .add("Battleship 2", ship2)
             .build();
 
-        assertEquals(ship1.getClass().isInstance(ship2), ship1.isFriend(ship2), context, r -> "Ship was not correctly identified as Friend or Foe.");
+        assertEquals(ship1.getClass().isInstance(ship2), IS_FRIEND_METHOD.invoke(context, ship1, ship2), context, r -> "Ship was not correctly identified as Friend or Foe.");
     }
 
     @ParameterizedTest
@@ -84,8 +88,10 @@ public class BattleShipTest {
         state.getSprites().add(firstBullet);
         state.getToAdd().add(firstBullet);
 
+        IS_ALIVE_METHOD.doReturnAlways(context,firstBullet, true);
+
         ship.setBullet(firstBullet);
-        ship.shoot(direction);
+        SHOOT_METHOD.invoke(context, ship, direction);
 
         Assertions2.call(
             () -> verify(ship, atMostOnce()).setBullet(any()),
@@ -117,11 +123,11 @@ public class BattleShipTest {
             .add("Direction", direction)
             .build();
 
-        ship.shoot(direction);
+        SHOOT_METHOD.invoke(context, ship, direction);
         final Bullet bullet = ship.getBullet();
 
         assertNotNull(bullet, context, r -> "Bullet was not created or not added to Ship");
-        assertEquals(direction, bullet.getDirection(), context, r -> "Bullet Direction did not match expected");
+        assertEquals(direction, Objects.requireNonNull(bullet).getDirection(), context, r -> "Bullet Direction did not match expected");
         assertTrue(state.getToAdd().contains(bullet), context, r -> "GameState toAdd list does not contain created Bullet");
 
         assertEquals(ship.getBounds().getCenterX(), bullet.getBounds().getCenterX(), context, r -> "Bullet is not correctly centered on BattleShip. X coordinate is not Correct");
@@ -134,6 +140,7 @@ public class BattleShipTest {
      * @return a ArgumentSets containing all arguments for the test
      */
     private static ArgumentSets provideIsFriend() {
+        ApplicationSettings.loadTexturesProperty().set(false);
         final List<BattleShip> ships = List.of(
             new BattleShip(0, 0, 0, Color.AQUA, 1, mock(GameState.class)),
             new BattleShip(10, 10, 5, Color.AQUA, 1, mock(GameState.class)),

--- a/src/graderPublic/java/h13/model/gameplay/sprites/EnemyTest.java
+++ b/src/graderPublic/java/h13/model/gameplay/sprites/EnemyTest.java
@@ -3,11 +3,15 @@ package h13.model.gameplay.sprites;
 import h13.controller.ApplicationSettings;
 import h13.model.gameplay.Direction;
 import h13.model.gameplay.GameState;
+import h13.util.PrettyPrinter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sourcegrade.jagr.api.rubric.TestForSubmission;
 
+import static h13.util.StudentLinks.BattleShipLinks.BattleShipMethodLink.SHOOT_METHOD;
+import static h13.util.StudentLinks.EnemyLinks.EnemyMethodLink.UPDATE_METHOD;
 import static org.mockito.Mockito.*;
+import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.contextBuilder;
 
 @TestForSubmission
 public class EnemyTest {
@@ -24,15 +28,31 @@ public class EnemyTest {
     public void testUpdateShootCalledWithMaxProbability() {
         ApplicationSettings.enemyShootingProbabilityProperty().set(1);
         ApplicationSettings.enemyShootingDelayProperty().set(0);
-        enemy.update(10);
-        verify(enemy, times(1)).shoot(Direction.DOWN);
+        final var context = contextBuilder()
+            .add("enemy", PrettyPrinter.prettyPrint(enemy))
+            .add("shootingProbability", ApplicationSettings.enemyShootingProbabilityProperty().get())
+            .add("shootingDelay", ApplicationSettings.enemyShootingDelayProperty().get())
+            .add("elapsedTime", 10)
+            .add("requires other methods to work:", "super.update(elapsedTime)")
+            .build();
+        UPDATE_METHOD.invoke(context, enemy, 10);
+        SHOOT_METHOD.assertInvokedNTimesWithParams(context, enemy, 1, Direction.DOWN);
     }
 
     @Test
     public void testUpdateWithMinProbability() {
         ApplicationSettings.enemyShootingProbabilityProperty().set(0);
         ApplicationSettings.enemyShootingDelayProperty().set(0);
-        enemy.update(0);
-        verify(enemy, never()).shoot(Direction.DOWN);
+
+        final var context = contextBuilder()
+            .add("enemy", PrettyPrinter.prettyPrint(enemy))
+            .add("shootingProbability", ApplicationSettings.enemyShootingProbabilityProperty().get())
+            .add("shootingDelay", ApplicationSettings.enemyShootingDelayProperty().get())
+            .add("elapsedTime", 0)
+            .add("requires other methods to work:", "super.update(elapsedTime)")
+            .build();
+
+        UPDATE_METHOD.invoke(context, enemy, 0);
+        verify(enemy, never()).shoot(any());
     }
 }

--- a/src/graderPublic/java/h13/model/gameplay/sprites/PlayerTest.java
+++ b/src/graderPublic/java/h13/model/gameplay/sprites/PlayerTest.java
@@ -2,15 +2,21 @@ package h13.model.gameplay.sprites;
 
 import h13.controller.ApplicationSettings;
 import h13.model.gameplay.GameState;
+import h13.util.PrettyPrinter;
+import h13.util.StudentLinks;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sourcegrade.jagr.api.rubric.TestForSubmission;
 
+import static h13.util.StudentLinks.PlayerLinks.PlayerMethodLink.SHOOT_METHOD;
+import static h13.util.StudentLinks.PlayerLinks.PlayerMethodLink.UPDATE_METHOD;
 import static org.mockito.Mockito.*;
+import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.contextBuilder;
 
 @TestForSubmission
 public class PlayerTest {
     private Player player;
+
     @BeforeEach
     public void setup() {
         ApplicationSettings.loadTexturesProperty().set(false);
@@ -20,14 +26,28 @@ public class PlayerTest {
     @Test
     public void testUpdateWithKeepShooting() {
         player.setKeepShooting(true);
-        player.update(0);
-        verify(player, times(1)).shoot();
+        final var context = contextBuilder()
+            .add("player", PrettyPrinter.prettyPrint(player))
+            .add("keepShooting", player.isKeepShooting())
+            .add("elapsedTime", 0)
+            .add("requires other methods to work:", "super.update(elapsedTime)")
+            .build();
+
+        UPDATE_METHOD.invoke(context, player, 0);
+        SHOOT_METHOD.assertInvokedNTimesWithParams(context, player, 1);
     }
 
     @Test
     public void testUpdateWithoutKeepShooting() {
         player.setKeepShooting(false);
-        player.update(0);
-        verify(player, never()).shoot();
+        final var context = contextBuilder()
+            .add("player", PrettyPrinter.prettyPrint(player))
+            .add("keepShooting", player.isKeepShooting())
+            .add("elapsedTime", 0)
+            .add("requires other methods to work:", "super.update(elapsedTime)")
+            .build();
+
+        UPDATE_METHOD.invoke(context, player, 0);
+        SHOOT_METHOD.assertNeverInvoked(context, player);
     }
 }

--- a/src/graderPublic/java/h13/model/gameplay/sprites/SpriteTest.java
+++ b/src/graderPublic/java/h13/model/gameplay/sprites/SpriteTest.java
@@ -15,6 +15,7 @@ import org.sourcegrade.jagr.api.rubric.TestForSubmission;
 import org.tudalgo.algoutils.tutor.general.assertions.Context;
 
 import static h13.util.StudentLinks.GameConstantsLinks.GameConstantsFieldLink.ORIGINAL_GAME_BOUNDS_FIELD;
+import static h13.util.StudentLinks.SpriteLinks.SpriteMethodLink.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.Mockito.*;
@@ -24,7 +25,7 @@ import static org.tudalgo.algoutils.tutor.general.assertions.Assertions2.*;
 public class SpriteTest {
 
     @Nested
-    public class IsDead{
+    public class IsDead {
 
         @ParameterizedTest
         @ValueSource(ints = {1, 2, 3, 763, Integer.MAX_VALUE})
@@ -34,7 +35,7 @@ public class SpriteTest {
                 .add("Sprite Health", health)
                 .build();
 
-            assertTrue(s.isAlive(), context, r -> String.format("Sprite is wrongly marked as dead with %d health", health));
+            assertTrue(IS_ALIVE_METHOD.invoke(context, s), context, r -> String.format("Sprite is wrongly marked as dead with %d health", health));
         }
 
         @ParameterizedTest
@@ -45,7 +46,7 @@ public class SpriteTest {
                 .add("Sprite Health", health)
                 .build();
 
-            assertTrue(s.isDead(), context, r -> String.format("Sprite is wrongly marked as not dead with %d health", health));
+            assertTrue(IS_DEAD_METHOD.invoke(context, s), context, r -> String.format("Sprite is wrongly marked as not dead with %d health", health));
         }
     }
 
@@ -58,7 +59,7 @@ public class SpriteTest {
             .add("Applied Damage", health)
             .build();
 
-        s.damage(damage);
+        DAMAGE_METHOD_WITH_AMOUNT.invoke(context, s, damage);
 
         final int expected = health - damage;
         final int actual = s.getHealth();
@@ -73,7 +74,7 @@ public class SpriteTest {
             .add("Sprite Health", health)
             .build();
 
-        s.die();
+        DIE_METHOD.invoke(context, s);
 
         assertEquals(0, s.getHealth(), context, r -> String.format("The Sprite should have had 0 health but actually had %d health", health));
     }
@@ -88,7 +89,7 @@ public class SpriteTest {
             .add("Next Position", destination)
             .build();
 
-        try (final var utilsMock = mockStatic(Utils.class)){
+        try (final var utilsMock = mockStatic(Utils.class)) {
             utilsMock.when(() -> Utils.getNextPosition(
                     any(Bounds.class),
                     anyDouble(),
@@ -102,7 +103,7 @@ public class SpriteTest {
                 .thenReturn(destination);
 
             final Sprite sprite = createSprite(1);
-            sprite.update(0);
+            UPDATE_METHOD.invoke(context, sprite, 0);
 
             utilsMock.verify(() -> Utils.getNextPosition(
                 any(Bounds.class),
@@ -120,8 +121,8 @@ public class SpriteTest {
             assertTrue(argumentSetX.getAllValues().stream().noneMatch(d -> isOutOfBounds(sprite, d, true)), context, r -> String.format("SetX was called with out of bounds coordinates. Called Values: %s", argumentSetX.getAllValues()));
             assertTrue(argumentSetY.getAllValues().stream().noneMatch(d -> isOutOfBounds(sprite, d, false)), context, r -> String.format("SetY was called with out of bounds coordinates. Called Values: %s", argumentSetY.getAllValues()));
 
-            assertEquals(destination.getMinX(), sprite.getX(), context, r-> "Sprite was not clamped to the correct X-Coordinate");
-            assertEquals(destination.getMinY(), sprite.getY(), context, r-> "Sprite was not clamped to the correct Y-Coordinate");
+            assertEquals(destination.getMinX(), sprite.getX(), context, r -> "Sprite was not clamped to the correct X-Coordinate");
+            assertEquals(destination.getMinY(), sprite.getY(), context, r -> "Sprite was not clamped to the correct Y-Coordinate");
         }
     }
 
@@ -136,7 +137,7 @@ public class SpriteTest {
             .add("Next Position", destination)
             .build();
 
-        try (final var utilsMock = mockStatic(Utils.class)){
+        try (final var utilsMock = mockStatic(Utils.class)) {
             utilsMock.when(() -> Utils.getNextPosition(
                     any(Bounds.class),
                     anyDouble(),
@@ -151,8 +152,8 @@ public class SpriteTest {
                 .thenReturn(new BoundingBox(50, 50, 1, 1));
 
             final Sprite sprite = createSprite(1);
-            sprite.update(0);
-
+            UPDATE_METHOD.invoke(context, sprite, 0);
+            
             utilsMock.verify(() -> Utils.getNextPosition(
                 any(Bounds.class),
                 anyDouble(),
@@ -173,23 +174,24 @@ public class SpriteTest {
             assertTrue(argumentSetX.getAllValues().stream().noneMatch(d -> isOutOfBounds(sprite, d, true)), context, r -> String.format("SetX was called with out of bounds coordinates. Called Values: %s", argumentSetX.getAllValues()));
             assertTrue(argumentSetY.getAllValues().stream().noneMatch(d -> isOutOfBounds(sprite, d, false)), context, r -> String.format("SetY was called with out of bounds coordinates. Called Values: %s", argumentSetY.getAllValues()));
 
-            assertEquals(clampedDestination.getMinX(), sprite.getX(), context, r-> "Sprite was not clamped to the correct X-Coordinate");
-            assertEquals(clampedDestination.getMinY(), sprite.getY(), context, r-> "Sprite was not clamped to the correct Y-Coordinate");
+            assertEquals(clampedDestination.getMinX(), sprite.getX(), context, r -> "Sprite was not clamped to the correct X-Coordinate");
+            assertEquals(clampedDestination.getMinY(), sprite.getY(), context, r -> "Sprite was not clamped to the correct Y-Coordinate");
         }
     }
 
     /**
      * Checks whether a coordinate is out of bounds or not
-     * @param sprite the sprite to check the coordinate for
+     *
+     * @param sprite     the sprite to check the coordinate for
      * @param coordinate the coordinate the sprite is placed at
-     * @param isX if the coordinate is the x coordinate of the sprite. false otherwise
+     * @param isX        if the coordinate is the x coordinate of the sprite. false otherwise
      * @return true if the sprite is out of bounds
      */
-    private static boolean isOutOfBounds(final Sprite sprite, final double coordinate, final boolean isX){
-        if (coordinate < 0){
+    private static boolean isOutOfBounds(final Sprite sprite, final double coordinate, final boolean isX) {
+        if (coordinate < 0) {
             return true;
         }
-        if (isX){
+        if (isX) {
             return coordinate > GameConstants.ORIGINAL_GAME_BOUNDS.getWidth() - sprite.getWidth();
         } else {
             return coordinate > GameConstants.ORIGINAL_GAME_BOUNDS.getHeight() - sprite.getHeight();
@@ -198,10 +200,11 @@ public class SpriteTest {
 
     /**
      * Creates a Sprite with the given heath
+     *
      * @param health the health the Sprite should have after creation
      * @return the newly created sprite
      */
-    public static Sprite createSprite(final int health){
+    public static Sprite createSprite(final int health) {
         final Sprite s = mock(Sprite.class, Mockito.CALLS_REAL_METHODS);
         s.setHealth(health);
         return s;


### PR DESCRIPTION
This pr fixes some methods throwing random errors when not being implemented and completely isolates the Tests to the Methods being tested. This means that you can start implementing EnemyMovement before anything else for example and still get all points on this class. (H1 only)