### PR TITLE
Fix typo

### DIFF
--- a/src/graderPublic/java/h13/model/gameplay/sprites/BattleShipTest.java
+++ b/src/graderPublic/java/h13/model/gameplay/sprites/BattleShipTest.java
@@ -107,8 +107,8 @@ public class BattleShipTest {
             context,
             r -> "Ship.setBullet() was not called twice"
         );
-        assertTrue(state.getToAdd().contains(firstBullet), context, r -> "Orignal Bullet was removed but should not have been");
-        assertTrue(state.getSprites().contains(firstBullet), context, r -> "Orignal Bullet was removed but should not have been");
+        assertTrue(state.getToAdd().contains(firstBullet), context, r -> "Original Bullet was removed but should not have been");
+        assertTrue(state.getSprites().contains(firstBullet), context, r -> "Original Bullet was removed but should not have been");
         DIE_METHOD.verify(context, firstBullet, never());
     }
 


### PR DESCRIPTION
There are some more typos in the grader, but fixing those might cause issues since some of them are in the JSON files or in method names, so I don't want to risk breaking the private grader or something like that