### PR TITLE
Improve Enemy test to allow for more solutions

### DIFF
--- a/src/graderPublic/java/h13/model/gameplay/sprites/EnemyTest.java
+++ b/src/graderPublic/java/h13/model/gameplay/sprites/EnemyTest.java
@@ -22,12 +22,12 @@ public class EnemyTest {
         ApplicationSettings.loadTexturesProperty().set(false);
         ApplicationSettings.enemyShootingDelayProperty().set(0);
         // replace Math.random() calls in Enemy with MathRandomTester.random() calls
-        enemy = spy(new Enemy(0, 0, 0, 0, mock(GameState.class)));
     }
 
     @Test
     public void testUpdateShootCalledWithMaxProbability() {
         ApplicationSettings.enemyShootingProbabilityProperty().set(1);
+        enemy = spy(new Enemy(0, 0, 0, 0, mock(GameState.class)));
         final var context = contextBuilder()
             .add("enemy", PrettyPrinter.prettyPrint(enemy))
             .add("shootingProbability", ApplicationSettings.enemyShootingProbabilityProperty().get())
@@ -42,7 +42,7 @@ public class EnemyTest {
     @Test
     public void testUpdateWithMinProbability() {
         ApplicationSettings.enemyShootingProbabilityProperty().set(0);
-
+        enemy = spy(new Enemy(0, 0, 0, 0, mock(GameState.class)));
         final var context = contextBuilder()
             .add("enemy", PrettyPrinter.prettyPrint(enemy))
             .add("shootingProbability", ApplicationSettings.enemyShootingProbabilityProperty().get())

--- a/src/graderPublic/java/h13/model/gameplay/sprites/EnemyTest.java
+++ b/src/graderPublic/java/h13/model/gameplay/sprites/EnemyTest.java
@@ -20,6 +20,7 @@ public class EnemyTest {
     @BeforeEach
     public void setup() {
         ApplicationSettings.loadTexturesProperty().set(false);
+        ApplicationSettings.enemyShootingDelayProperty().set(0);
         // replace Math.random() calls in Enemy with MathRandomTester.random() calls
         enemy = spy(new Enemy(0, 0, 0, 0, mock(GameState.class)));
     }
@@ -27,7 +28,6 @@ public class EnemyTest {
     @Test
     public void testUpdateShootCalledWithMaxProbability() {
         ApplicationSettings.enemyShootingProbabilityProperty().set(1);
-        ApplicationSettings.enemyShootingDelayProperty().set(0);
         final var context = contextBuilder()
             .add("enemy", PrettyPrinter.prettyPrint(enemy))
             .add("shootingProbability", ApplicationSettings.enemyShootingProbabilityProperty().get())
@@ -42,7 +42,6 @@ public class EnemyTest {
     @Test
     public void testUpdateWithMinProbability() {
         ApplicationSettings.enemyShootingProbabilityProperty().set(0);
-        ApplicationSettings.enemyShootingDelayProperty().set(0);
 
         final var context = contextBuilder()
             .add("enemy", PrettyPrinter.prettyPrint(enemy))


### PR DESCRIPTION
This pull request aims to address the test failing even though a class attribute has been implemented properly in order to track the next point in time at which shooting is allowed.
It fails due to the standard enemyShootingDelayProperty being set to 1000, and then being changed to 0 in the tests, after the enemy spy has been created, therefore if one was to implement a solution relying on an attribute being set to the enemyShootingDelayProperty in the constructor, that solution would fail due to the attribute being set to the wrong value.