### PR TITLE
Fix/remove drawHUD() tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,9 @@ jagr {
                             "-Dtestfx.robot=glass",
                             "-Dtestfx.headless=true",
                             "-Dprism.order=sw",
-                            "-Djdk.attach.allowAttachSelf=true"
+                            "-Djdk.attach.allowAttachSelf=true",
+                            "-Dprism.lcdtext=false",
+                            "-Dprism.subpixeltext=false"
                         )
                     ),
                     transformers = Transformers(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,9 +44,10 @@ jagr {
                             "-Dtestfx.robot=glass",
                             "-Dtestfx.headless=true",
                             "-Dprism.order=sw",
-                            "-Djdk.attach.allowAttachSelf=true",
                             "-Dprism.lcdtext=false",
-                            "-Dprism.subpixeltext=false"
+                            "-Dprism.subpixeltext=false",
+                            "-Dglass.win.uiScale=100%",
+                            "-Dprism.text=t2k"
                         )
                     ),
                     transformers = Transformers(

--- a/src/graderPublic/java/h13/H13_RubricProvider.java
+++ b/src/graderPublic/java/h13/H13_RubricProvider.java
@@ -227,10 +227,17 @@ public class H13_RubricProvider implements RubricProvider {
                                 "Die Methode drawSprites() ist vollständig korrekt.",
                                 JUnitTestRef.ofMethod(() -> GameBoardTest.class.getDeclaredMethod("testDrawSprites", JsonParameterSet.class))
                             ),
-                            criterion(
-                                "Die Methode drawHUD() ist vollständig korrekt.",
-                                JUnitTestRef.ofMethod(() -> GameBoardTest.class.getDeclaredMethod("testDrawHUD", int.class, int.class))
-                            ),
+                            // This test is Platform-Dependant. If it works, you can be sure that it will work for the Private tests as well
+//                            criterion(
+//                                "Die Methode drawHUD() ist vollständig korrekt.",
+//                                JUnitTestRef.ofMethod(() -> GameBoardTest.class.getDeclaredMethod("testDrawHUD", int.class, int.class))
+//                            ),
+                            Criterion.builder()
+                                .shortDescription("Die Methode drawHUD() ist vollständig korrekt.")
+                                .grader(graderPrivateOnly())
+                                .minPoints(0)
+                                .maxPoints(1)
+                                .build(),
                             criterion(
                                 "Die Methode drawBorder() ist vollständig korrekt.",
                                 JUnitTestRef.ofMethod(() -> GameBoardTest.class.getDeclaredMethod("testDrawBorder", String.class, int.class))

--- a/src/graderPublic/java/h13/view/gui/GameBoardTest.java
+++ b/src/graderPublic/java/h13/view/gui/GameBoardTest.java
@@ -18,6 +18,7 @@ import javafx.geometry.BoundingBox;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import javafx.scene.text.FontSmoothingType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -74,6 +75,8 @@ public class GameBoardTest extends FxTest {
         //setup graphics Context
         final Canvas canvas = new Canvas(GameConstants.ORIGINAL_GAME_BOUNDS.getWidth(), GameConstants.ORIGINAL_GAME_BOUNDS.getHeight());
         graphicsContext = canvas.getGraphicsContext2D();
+        graphicsContext.setImageSmoothing(true);
+        graphicsContext.setFontSmoothingType(FontSmoothingType.GRAY);
 
         //mock needed Objects
         player = spy(mock(Player.class, CALLS_REAL_METHODS));

--- a/src/graderPublic/java/h13/view/gui/SpriteRendererTest.java
+++ b/src/graderPublic/java/h13/view/gui/SpriteRendererTest.java
@@ -16,6 +16,7 @@ import javafx.geometry.Bounds;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
+import javafx.scene.text.FontSmoothingType;
 import org.junit.jupiter.api.BeforeEach;
 
 import static org.mockito.Mockito.mock;
@@ -69,25 +70,27 @@ public class SpriteRendererTest extends FxTest {
     }
 
     private void runTest(final JsonParameterSet params){
-            final String fileName = params.getString("image");
-            final Bounds bounds = params.get("GAME_BOUNDS");
-            final List<Sprite> sprites = params.get("sprites");
+        final String fileName = params.getString("image");
+        final Bounds bounds = params.get("GAME_BOUNDS");
+        final List<Sprite> sprites = params.get("sprites");
 
-            final BufferedImage generatedImage = SwingFXUtils.fromFXImage(generateImage(bounds, sprites), null);
-            final BufferedImage expectedImage = FxTest.loadImage(fileName);
+        final BufferedImage generatedImage = SwingFXUtils.fromFXImage(generateImage(bounds, sprites), null);
+        final BufferedImage expectedImage = FxTest.loadImage(fileName);
 
-            final Context context = contextBuilder()
-                .add("Loaded Image", fileName)
-                .add("Sprites", PrettyPrinter.prettyPrint(sprites))
-                .add("bounds", bounds)
-                .build();
+        final Context context = contextBuilder()
+            .add("Loaded Image", fileName)
+            .add("Sprites", PrettyPrinter.prettyPrint(sprites))
+            .add("bounds", bounds)
+            .build();
 
-            assertEqualsImage(expectedImage, generatedImage, context);
+        assertEqualsImage(expectedImage, generatedImage, context);
     }
 
     private static Image generateImage(final Bounds bounds, final List<Sprite> spritesToRender){
         final Canvas canvas = new Canvas(bounds.getWidth(), bounds.getHeight());
         final var gc = canvas.getGraphicsContext2D();
+        gc.setImageSmoothing(true);
+        gc.setFontSmoothingType(FontSmoothingType.GRAY);
 
         gc.setFill(Color.BLACK);
         gc.fillRect(0,0, bounds.getWidth(), bounds.getHeight());


### PR DESCRIPTION
The drawHUD() test is highly platform-dependant. If it runs through on your plaform you can be assured that it will also work in the private grader (unless you hardcoded it) but if it fails you might still have a perfectly working implementation, so we remove it from the public tests